### PR TITLE
Improve Export SVG Standard Compliance

### DIFF
--- a/packages/scannable/src/qr/renderer/renderSVG.ts
+++ b/packages/scannable/src/qr/renderer/renderSVG.ts
@@ -75,7 +75,7 @@ export const renderSVG = (
 
 	return `<svg width="${processedOptions.width}" height=$"{
 		processedOptions.height
-	}">${rectangles
+	}" xmlns="http://www.w3.org/2000/svg">${rectangles
 		.map(
 			({ x, y, enabled }) =>
 				`<rect width="${moduleSizeWidth}" height="${moduleSizeHeight}" x="${x}" y="${y}" style="${generateStyle(

--- a/packages/scannable/src/qr/renderer/renderSVG.ts
+++ b/packages/scannable/src/qr/renderer/renderSVG.ts
@@ -73,7 +73,7 @@ export const renderSVG = (
 		}
 	}
 
-	return `<svg width="${processedOptions.width}" height=$"{
+	return `<svg width="${processedOptions.width}" height="${
 		processedOptions.height
 	}" xmlns="http://www.w3.org/2000/svg">${rectangles
 		.map(

--- a/packages/scannable/src/qr/renderer/renderSVG.ts
+++ b/packages/scannable/src/qr/renderer/renderSVG.ts
@@ -73,9 +73,9 @@ export const renderSVG = (
 		}
 	}
 
-	return `<svg width=${processedOptions.width} height=${
+	return `<svg width="${processedOptions.width}" height=$"{
 		processedOptions.height
-	}>${rectangles
+	}">${rectangles
 		.map(
 			({ x, y, enabled }) =>
 				`<rect width="${moduleSizeWidth}" height="${moduleSizeHeight}" x="${x}" y="${y}" style="${generateStyle(


### PR DESCRIPTION
This change would put SVG width and height values in quotes, and add an xmlns string pointing to the SVG standard, making the rendered SVG more compliant with standards. Generated SVGs from the original version do not pass W3C validation, but those made with the changed version do. They are also rendered correctly on my machine (Win10 Firefox 124.0.1), while those from the original version are not.

I ran the test suite and everything came back fine, but I'm not familiar with Node packaging so I wasn't able to install the package to test it that way. I made identical changes in an installed copy of the package to test instead, and I have carefully verified that the changes are identical.